### PR TITLE
Add Order interface

### DIFF
--- a/include/locked_queue.h
+++ b/include/locked_queue.h
@@ -4,6 +4,9 @@
 #include <shared_mutex>
 #include <functional>
 #include <memory>
+#include <iostream>
+#include <string>
+
 
 template<typename T, typename Compare = std::less<T>>
 class LockedPriorityQueue {
@@ -13,7 +16,7 @@ public:
     void pop();
     T top() const;
     bool empty() const;
-    void print() const;
+    // std::ostream& operator<<(std::ostream& os, LockedPriorityQueue<T, Compare> const & queue);
 private:
     mutable std::shared_mutex mutex_;
     std::priority_queue<T, std::vector<T>, Compare> heap_;

--- a/include/order.h
+++ b/include/order.h
@@ -18,6 +18,7 @@ public:
     void deactivate();
     bool operator==(const Order& rhs) const;
     bool operator!=(const Order& rhs) const;
+    std::string typeName() const;
 protected:
     std::string symbol_;
     double price_;
@@ -30,6 +31,7 @@ class Bid: public Order {
 public:
     Bid();
     Bid(const std::string& symbol, double price, double volume);
+    Bid(const Order& order);
     virtual ~Bid() = default;
     /*
      * Comparator overloads sort by price-time priority.
@@ -38,12 +40,14 @@ public:
      */
     bool operator<(const Bid& rhs) const;
     bool operator>(const Bid& rhs) const;
+    std::string typeName() const;
 };
 
 class Ask: public Order {
 public:
     Ask();
     Ask(const std::string& symbol, double price, double volume);
+    Ask(const Order& order);
     /*
      * Comparator overloads sort by price-time priority.
      * If order1 has a better price than order2, then order1 is given priority
@@ -51,23 +55,36 @@ public:
      */
     bool operator<(const Ask& rhs) const;
     bool operator>(const Ask& rhs) const;
+    std::string typeName() const;
 };
 
-std::ostream& operator<<(std::ostream& os, Order const & order);
+std::ostream& operator<<(std::ostream& os, Ask const & order);
+
+std::ostream& operator<<(std::ostream& os, Bid const & order);
+
 
 #ifdef ENABLE_DOCTEST_IN_LIBRARY
 #include "doctest/doctest.h"
 TEST_CASE("test order initialization")
 {
-    Order o;
-    CHECK(o.symbol() == "AAPL");
-    CHECK(o.price() == 0.0);
-    CHECK(o.volume() == 0.0);
+    Ask a;
+    CHECK(a.symbol() == "AAPL");
+    CHECK(a.price() == 0.0);
+    CHECK(a.volume() == 0.0);
+
+    // Check that error is raised when volume is negative
+    CHECK_THROWS(Ask("AAPL", 10.0, 100.0));
 
     std::stringstream ss;
-    ss << o;
+    ss << a;
     // CHECK(ss.str() == "foobar");
-    CHECK(ss.str().find("Order") == 0);
+    CHECK(ss.str().find("Ask") == 0);
+
+    Bid b {"AAPL", 10.0, 100.0};
+    std::stringstream ss2;
+    ss2 << b;
+    CHECK(ss2.str().find("Bid") == 0);
+    CHECK_THROWS(Bid("AAPL", 10.0, -100.0));
 }
 
 TEST_CASE("test operator overloads")

--- a/include/order.h
+++ b/include/order.h
@@ -18,11 +18,11 @@ public:
     void deactivate();
     bool operator==(const Order& rhs) const;
     bool operator!=(const Order& rhs) const;
-private:
+protected:
     std::string symbol_;
-    TimePoint timePlaced_;
     double price_;
     double volume_;
+    TimePoint timePlaced_;
     bool isActive_;
 };
 
@@ -72,18 +72,25 @@ TEST_CASE("test order initialization")
 
 TEST_CASE("test operator overloads")
 {
-    Order o1 {"AAPL", 10.0, 100.0};
-    Order o2 {"AAPL", 50.0, 100.0};
-    Order o3 {"AAPL", 40.0, -10.0};
-    Order o4 {"AAPL", 50.0, 100.0};
-    Order o5 {"AAPL", 50.0, 100.0};
-    CHECK(o1 < o2);
-    CHECK(o2 > o3);
-    CHECK(o2 == o4);
+    Bid b0 {"AAPL", 10.0, 100.0};
+    Bid b1 {"AAPL", 10.0, 100.0};
+    Bid b2 {"AAPL", 50.0, 100.0};
+    Bid b3 {"AAPL", 40.0, 10.0};
+    Ask a0 {"AAPL", 50.0, -100.0};
+    Ask a1 {"AAPL", 50.0, -100.0};
+    Ask a2 {"AAPL", 60.0, -100.0};
 
-    // Due to time priority
-    CHECK(o4 != o5);
-    CHECK(o5 < o4);
-    CHECK(o4 > o5);
+    // Check operator overloads, which represent price-time priority
+    CHECK(b0 != b1); // Different timePlaced
+    CHECK(b0 > b1); // Same price, but b0 placed earlier
+    CHECK(b1 < b2);
+    CHECK(b2 > b1);
+    CHECK(b2 > b3);
+
+    // Check overloads for asks
+    CHECK(a0 > a2);
+    CHECK(a2 > a0);
+    CHECK(a0 != a1);
+    CHECK(a0 > a1); // Same price, but a0 placed earlier
 }
 #endif

--- a/include/order.h
+++ b/include/order.h
@@ -22,6 +22,7 @@ private:
     bool isActive_;
 };
 
+std::ostream& operator<<(std::ostream& os, Order const & order);
 
 #ifdef ENABLE_DOCTEST_IN_LIBRARY
 #include "doctest/doctest.h"

--- a/include/order.h
+++ b/include/order.h
@@ -9,16 +9,13 @@ class Order {
 public:
     Order();
     Order(const std::string& symbol, double price, double volume);
+    virtual ~Order() = default;
     std::string symbol() const;
     double price() const;
     double volume() const;
     TimePoint timePlaced() const;
-    bool isSell() const;
-    bool isBuy() const;
     bool isActive() const;
     void deactivate();
-    bool operator<(const Order& rhs) const;
-    bool operator>(const Order& rhs) const;
     bool operator==(const Order& rhs) const;
     bool operator!=(const Order& rhs) const;
 private:
@@ -27,6 +24,33 @@ private:
     double price_;
     double volume_;
     bool isActive_;
+};
+
+class Bid: public Order {
+public:
+    Bid();
+    Bid(const std::string& symbol, double price, double volume);
+    virtual ~Bid() = default;
+    /*
+     * Comparator overloads sort by price-time priority.
+     * If order1 has a better price than order2, then order1 is given priority
+     * and order1 > order2.
+     */
+    bool operator<(const Bid& rhs) const;
+    bool operator>(const Bid& rhs) const;
+};
+
+class Ask: public Order {
+public:
+    Ask();
+    Ask(const std::string& symbol, double price, double volume);
+    /*
+     * Comparator overloads sort by price-time priority.
+     * If order1 has a better price than order2, then order1 is given priority
+     * and order1 > order2.
+     */
+    bool operator<(const Ask& rhs) const;
+    bool operator>(const Ask& rhs) const;
 };
 
 std::ostream& operator<<(std::ostream& os, Order const & order);

--- a/include/order.h
+++ b/include/order.h
@@ -106,7 +106,7 @@ TEST_CASE("test operator overloads")
 
     // Check overloads for asks
     CHECK(a0 > a2);
-    CHECK(a2 > a0);
+    CHECK(a2 < a0);
     CHECK(a0 != a1);
     CHECK(a0 > a1); // Same price, but a0 placed earlier
 }

--- a/include/order.h
+++ b/include/order.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <sstream>
 
 class Order {
 public:

--- a/include/order.h
+++ b/include/order.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <string>
 #include <sstream>
+#include <chrono>
+
+using TimePoint = std::chrono::time_point<std::chrono::system_clock>;
 
 class Order {
 public:
@@ -9,6 +12,7 @@ public:
     std::string symbol() const;
     double price() const;
     double volume() const;
+    TimePoint timePlaced() const;
     bool isSell() const;
     bool isBuy() const;
     bool isActive() const;
@@ -16,8 +20,10 @@ public:
     bool operator<(const Order& rhs) const;
     bool operator>(const Order& rhs) const;
     bool operator==(const Order& rhs) const;
+    bool operator!=(const Order& rhs) const;
 private:
     std::string symbol_;
+    TimePoint timePlaced_;
     double price_;
     double volume_;
     bool isActive_;
@@ -33,6 +39,11 @@ TEST_CASE("test order initialization")
     CHECK(o.symbol() == "AAPL");
     CHECK(o.price() == 0.0);
     CHECK(o.volume() == 0.0);
+
+    std::stringstream ss;
+    ss << o;
+    // CHECK(ss.str() == "foobar");
+    CHECK(ss.str().find("Order") == 0);
 }
 
 TEST_CASE("test operator overloads")
@@ -41,8 +52,14 @@ TEST_CASE("test operator overloads")
     Order o2 {"AAPL", 50.0, 100.0};
     Order o3 {"AAPL", 40.0, -10.0};
     Order o4 {"AAPL", 50.0, 100.0};
+    Order o5 {"AAPL", 50.0, 100.0};
     CHECK(o1 < o2);
     CHECK(o2 > o3);
     CHECK(o2 == o4);
+
+    // Due to time priority
+    CHECK(o4 != o5);
+    CHECK(o5 < o4);
+    CHECK(o4 > o5);
 }
 #endif

--- a/src/locked_queue.cpp
+++ b/src/locked_queue.cpp
@@ -31,13 +31,14 @@ bool LockedPriorityQueue<T, Compare>::empty() const
     return heap_.empty();
 }
 
-template<typename T, typename Compare>
-void LockedPriorityQueue<T, Compare>::print() const
-{
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    std::priority_queue<T, std::vector<T>, Compare> heapCopy = heap_;
-    while (!heapCopy.empty()) {
-        std::cout << heapCopy.top() << "\n" << std::endl;
-        heapCopy.pop();
-    }
-}
+// template<typename T, typename Compare>
+// std::ostream& LockedPriorityQueue<T, Compare>::operator<<(std::ostream& os, LockedPriorityQueue<T, Compare> const & queue) {
+//     std::shared_lock<std::shared_mutex> lock(mutex_);
+//     std::priority_queue<T, std::vector<T>, Compare> heapCopy = heap_;
+//     os << "LockedPriorityQueue(";
+//     while (!heapCopy.empty()) {
+//         os << heapCopy.top() << ", ";
+//         heapCopy.pop();
+//     }
+//     os << ")";
+// }

--- a/src/matching_engine.cpp
+++ b/src/matching_engine.cpp
@@ -23,10 +23,8 @@ void MatchingEngine::cancelOrder(const Order& order)
 
 void MatchingEngine::printOrderBook() const
 {
-    std::cout << "Buy Orders:" << std::endl;
-    buyOrders_.print();
-    std::cout << "Sell Orders:" << std::endl;
-    sellOrders_.print();
+    std::cout << "Buy Orders:" << "\n" << buyOrders_ << std::endl;
+    std::cout << "Sell Orders:" << "\n" << buyOrders_ << std::endl;
 }
 
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -60,7 +60,9 @@ bool Order::operator==(const Order& rhs) const
 
 
 std::ostream& operator<<(std::ostream& os, Order const & order) {
-    os << "Order(symbol=" << order.symbol() << ", price=" << order.price();
-    os << ", volume=" << order.volume() << ", isActive=" << order.isActive() << ")";
+    std::stringstream ss;
+    ss << "Order(symbol=" << order.symbol() << ", price=" << order.price();
+    ss << ", volume=" << order.volume() << ", isActive=" << order.isActive() << ")";
+    os << ss.str();
     return os;
 }

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -42,26 +42,6 @@ void Order::deactivate()
     isActive_ = false;
 }
 
-bool Order::isSell() const
-{
-    return volume_ < 0.0;
-}
-
-bool Order::isBuy() const
-{
-    return volume_ > 0.0;
-}
-
-bool Order::operator<(const Order& rhs) const
-{
-    return price_ < rhs.price_;
-}
-
-bool Order::operator>(const Order& rhs) const
-{
-    return price_ > rhs.price_;
-}
-
 bool Order::operator==(const Order& rhs) const
 {
     return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_;
@@ -72,9 +52,41 @@ bool Order::operator!=(const Order& rhs) const
     return !(*this == rhs);
 }
 
+bool Bid::operator<(const Bid& rhs) const
+{
+    return price_ < rhs.price_;
+}
+
+bool Bid::operator>(const Bid& rhs) const
+{
+    return price_ > rhs.price_;
+}
+
+bool Bid::operator==(const Bid& rhs) const
+{
+    return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_;
+}
+
+bool Bid::operator!=(const Bid& rhs) const
+{
+    return !(*this == rhs);
+}
+
+bool Ask::operator<(const Ask& rhs) const
+{
+    // Reversed because asks with lower price have higher priority.
+    return price_ > rhs.price_;
+}
+
+bool Ask::operator>(const Ask& rhs) const
+{
+    return price_ < rhs.price_;
+}
+
 std::ostream& operator<<(std::ostream& os, Order const & order) {
     std::stringstream ss;
-    ss << "Order(symbol=" << order.symbol() << ", price=" << order.price();
+    ss << decltype(order)::name() << "(";
+    ss << "(symbol=" << order.symbol() << ", price=" << order.price();
     ss << ", volume=" << order.volume() << ", isActive=" << order.isActive();
     ss << ", timePlaced=" << std::chrono::system_clock::to_time_t(order.timePlaced());
     ss << ")";

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -58,3 +58,9 @@ bool Order::operator==(const Order& rhs) const
     return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_;
 }
 
+
+std::ostream& operator<<(std::ostream& os, Order const & order) {
+    os << "Order(symbol=" << order.symbol() << ", price=" << order.price();
+    os << ", volume=" << order.volume() << ", isActive=" << order.isActive() << ")";
+    return os;
+}

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -50,6 +50,11 @@ bool Order::operator!=(const Order& rhs) const
     return !(*this == rhs);
 }
 
+std::string Order::typeName() const
+{
+    return "Order";
+}
+
 Bid::Bid()
 : Order() {}
 
@@ -60,14 +65,30 @@ Bid::Bid(const std::string& symbol, double price, double volume)
     }
 }
 
+Bid::Bid(const Order& order) : Bid(order.symbol(), order.price(), order.volume()) {}
+
 bool Bid::operator<(const Bid& rhs) const
 {
-    return price_ < rhs.price_;
+    if (price_ == rhs.price_) {
+        // If prices are equal, then the order placed first has priority.
+        return timePlaced_ > rhs.timePlaced_;
+    } else {
+        return price_ < rhs.price_;
+    }
 }
 
 bool Bid::operator>(const Bid& rhs) const
 {
-    return price_ > rhs.price_;
+    if (price_ == rhs.price_) {
+        return timePlaced_ < rhs.timePlaced_;
+    } else {
+        return price_ > rhs.price_;
+    }
+}
+
+std::string Bid::typeName() const
+{
+    return "Bid";
 }
 
 Ask::Ask()
@@ -80,25 +101,49 @@ Ask::Ask(const std::string& symbol, double price, double volume)
     }
 }
 
+Ask::Ask(const Order& order) : Ask(order.symbol(), order.price(), order.volume()) {}
+
 bool Ask::operator<(const Ask& rhs) const
 {
-    // Reversed because asks with lower price have higher priority.
-    return price_ > rhs.price_;
+    if (price_ == rhs.price_) {
+        return timePlaced_ > rhs.timePlaced_;
+    } else {
+        // Lower price has priority for asks.
+        return price_ > rhs.price_;
+    }
 }
 
 bool Ask::operator>(const Ask& rhs) const
 {
-    return price_ < rhs.price_;
+    if (price_ == rhs.price_) {
+        return timePlaced_ < rhs.timePlaced_;
+    } else {
+        // Lower price has priority for asks.
+        return price_ < rhs.price_;
+    }
 }
 
+std::string Ask::typeName() const
+{
+    return "Ask";
+}
 
-std::ostream& operator<<(std::ostream& os, Order const & order) {
+std::ostream& operator<<(std::ostream& os, Bid const & order) {
     std::stringstream ss;
-    ss << typeid(order).name() << "(";
-    ss << "(symbol=" << order.symbol() << ", price=" << order.price();
-    ss << ", volume=" << order.volume() << ", isActive=" << order.isActive();
-    ss << ", timePlaced=" << std::chrono::system_clock::to_time_t(order.timePlaced());
-    ss << ")";
+    ss << order.typeName();
+    ss << "(symbol: " << order.symbol() << ", price: " << order.price() << ", volume: ";
+    ss << order.volume() << ", timePlaced: " << order.timePlaced().time_since_epoch().count();
+    ss << ", isActive: " << order.isActive() << ")";
+    os << ss.str();
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, Ask const & order) {
+    std::stringstream ss;
+    ss << order.typeName();
+    ss << "(symbol: " << order.symbol() << ", price: " << order.price() << ", volume: ";
+    ss << order.volume() << ", timePlaced: " << order.timePlaced().time_since_epoch().count();
+    ss << ", isActive: " << order.isActive() << ")";
     os << ss.str();
     return os;
 }

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -2,11 +2,15 @@
 
 Order::Order():
 symbol_("AAPL"), price_(0.0), volume_(0.0), isActive_(true)
-{}
+{
+    timePlaced_ = std::chrono::system_clock::now();
+}
 
 Order::Order(const std::string& symbol, double price, double volume):
 symbol_(symbol), price_(price), volume_(volume), isActive_(true)
-{}
+{
+    timePlaced_ = std::chrono::system_clock::now();
+}
 
 std::string Order::symbol() const
 {
@@ -21,6 +25,11 @@ double Order::price() const
 double Order::volume() const
 {
     return volume_;
+}
+
+TimePoint Order::timePlaced() const
+{
+    return timePlaced_;
 }
 
 bool Order::isActive() const
@@ -58,11 +67,17 @@ bool Order::operator==(const Order& rhs) const
     return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_;
 }
 
+bool Order::operator!=(const Order& rhs) const
+{
+    return !(*this == rhs);
+}
 
 std::ostream& operator<<(std::ostream& os, Order const & order) {
     std::stringstream ss;
     ss << "Order(symbol=" << order.symbol() << ", price=" << order.price();
-    ss << ", volume=" << order.volume() << ", isActive=" << order.isActive() << ")";
+    ss << ", volume=" << order.volume() << ", isActive=" << order.isActive();
+    ss << ", timePlaced=" << std::chrono::system_clock::to_time_t(order.timePlaced());
+    ss << ")";
     os << ss.str();
     return os;
 }

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1,16 +1,14 @@
 #include "order.h"
 
-Order::Order():
-symbol_("AAPL"), price_(0.0), volume_(0.0), isActive_(true)
-{
-    timePlaced_ = std::chrono::system_clock::now();
-}
+Order::Order()
+: symbol_("AAPL"), price_(0.0), volume_(0.0),
+  timePlaced_(std::chrono::system_clock::now()), isActive_(true)
+{}
 
-Order::Order(const std::string& symbol, double price, double volume):
-symbol_(symbol), price_(price), volume_(volume), isActive_(true)
-{
-    timePlaced_ = std::chrono::system_clock::now();
-}
+Order::Order(const std::string& symbol, double price, double volume)
+: symbol_(symbol), price_(price), volume_(volume),
+  timePlaced_(std::chrono::system_clock::now()), isActive_(true)
+{}
 
 std::string Order::symbol() const
 {
@@ -44,12 +42,22 @@ void Order::deactivate()
 
 bool Order::operator==(const Order& rhs) const
 {
-    return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_;
+    return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_ && timePlaced_ == rhs.timePlaced_;
 }
 
 bool Order::operator!=(const Order& rhs) const
 {
     return !(*this == rhs);
+}
+
+Bid::Bid()
+: Order() {}
+
+Bid::Bid(const std::string& symbol, double price, double volume)
+: Order(symbol, price, volume) {
+    if (volume < 0) {
+        throw std::invalid_argument("Bid volume must be positive.");
+    }
 }
 
 bool Bid::operator<(const Bid& rhs) const
@@ -62,14 +70,14 @@ bool Bid::operator>(const Bid& rhs) const
     return price_ > rhs.price_;
 }
 
-bool Bid::operator==(const Bid& rhs) const
-{
-    return symbol_ == rhs.symbol_ && price_ == rhs.price_ && volume_ == rhs.volume_;
-}
+Ask::Ask()
+: Order() {}
 
-bool Bid::operator!=(const Bid& rhs) const
-{
-    return !(*this == rhs);
+Ask::Ask(const std::string& symbol, double price, double volume)
+: Order(symbol, price, volume) {
+    if (volume > 0) {
+        throw std::invalid_argument("Ask volume must be negative.");
+    }
 }
 
 bool Ask::operator<(const Ask& rhs) const
@@ -83,9 +91,10 @@ bool Ask::operator>(const Ask& rhs) const
     return price_ < rhs.price_;
 }
 
+
 std::ostream& operator<<(std::ostream& os, Order const & order) {
     std::stringstream ss;
-    ss << decltype(order)::name() << "(";
+    ss << typeid(order).name() << "(";
     ss << "(symbol=" << order.symbol() << ", price=" << order.price();
     ss << ", volume=" << order.volume() << ", isActive=" << order.isActive();
     ss << ", timePlaced=" << std::chrono::system_clock::to_time_t(order.timePlaced());


### PR DESCRIPTION
Adds classes for `Bid`, `Ask`, and their parent `Order`.

## Commits
- WIP
- ostream overloads
- Failing tests for price-time priority
- WIP Bid/Ask child classes
- No compiler errors
- Fix operator<< template oddities
- Fix unit tests
